### PR TITLE
Allow external configuration

### DIFF
--- a/lib/kafka_notifier.rb
+++ b/lib/kafka_notifier.rb
@@ -33,7 +33,7 @@ module Redborder
 
     self.config = YAML.load(File.read('config/kafka.yml')).symbolize_keys
 
-    def self.start producer
+    def self.start producer=nil
       self.producer = producer || Poseidon::Producer.new(
         config[:brokers], config[:client_id], type: :sync,
         required_acks: 1, partitioner: partitioner

--- a/lib/kafka_notifier.rb
+++ b/lib/kafka_notifier.rb
@@ -33,8 +33,8 @@ module Redborder
 
     self.config = YAML.load(File.read('config/kafka.yml')).symbolize_keys
 
-    def self.start
-      self.producer = Poseidon::Producer.new(
+    def self.start producer
+      self.producer = producer || Poseidon::Producer.new(
         config[:brokers], config[:client_id], type: :sync,
         required_acks: 1, partitioner: partitioner
       )


### PR DESCRIPTION
Do not require that the producer be configured from within the notifiers config yaml.
